### PR TITLE
Fix incorrect constant name for nested modules/classes

### DIFF
--- a/lib/cacheable/method_generator.rb
+++ b/lib/cacheable/method_generator.rb
@@ -13,7 +13,7 @@ module Cacheable
     private
 
     def method_interceptor_module_name
-      class_name = name || to_s.gsub(/[^a-zA-Z_0-9]/, '')
+      class_name = name&.gsub(/:/, '') || to_s.gsub(/[^a-zA-Z_0-9]/, '')
       "#{class_name}Cacher"
     end
 

--- a/spec/cacheable/cacheable_spec.rb
+++ b/spec/cacheable/cacheable_spec.rb
@@ -117,6 +117,34 @@ RSpec.describe Cacheable do
         end
       end
     end
+
+    context 'when classes are nested' do
+      it 'correctly names interceptor modules' do
+        expect do
+          class Outer
+            class Inner
+              include Cacheable
+
+              cacheable :outer_method
+
+              def outer_method
+                inner_method
+                'outer_method'
+              end
+
+              def inner_method
+                puts 'inner_method'
+              end
+            end
+          end
+        end.not_to raise_error
+
+        cacheable_instance = Outer::Inner.new
+        expect(cacheable_instance).to receive(:inner_method).once.and_call_original
+
+        2.times { cacheable_instance.outer_method }
+      end
+    end
   end
 
   describe 'interceptor module' do


### PR DESCRIPTION
Method: Turn "Foo::Bar::Baz", the `name` value of the nested `Baz` class into Baz::FooBarBazCacher interceptor constant

[fixes #1]