### PR TITLE
remove puts from test

### DIFF
--- a/spec/cacheable/cacheable_spec.rb
+++ b/spec/cacheable/cacheable_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Cacheable do
               end
 
               def inner_method
-                puts 'inner_method'
+                'inner_method'
               end
             end
           end


### PR DESCRIPTION
Introduced by me in PR #8 https://github.com/splitwise/cacheable/pull/8/files#diff-a70e599c5e70da41d8f98e0f13dbd142R136

I know there's a [Rails Rubocop](https://docs.rubocop.org/en/latest/cops_rails/#railsoutput) for `puts` over `Rails.logger.#{type}`. Is there a cop for `puts` in spec files?