### PR TITLE
bump version number

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cacheable (1.0.3)
+    cacheable (1.0.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/cacheable/version.rb
+++ b/lib/cacheable/version.rb
@@ -4,7 +4,7 @@ module Cacheable
   module VERSION
     MAJOR = 1
     MINOR = 0
-    TINY = 3
+    TINY = 4
     PRE = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.').freeze


### PR DESCRIPTION
Up at https://rubygems.org/gems/cacheable/versions/1.0.4